### PR TITLE
Sniff the scheme in FullyQualifiedRedirectMiddleware rather than hardcoding it to http

### DIFF
--- a/pylib/djangomiddleware/redirect_middleware.py
+++ b/pylib/djangomiddleware/redirect_middleware.py
@@ -4,7 +4,6 @@ import urlparse
 import logging
 
 from django.http import HttpResponseRedirect
-from django.contrib.sites.models import Site
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -28,7 +27,7 @@ class FullyQualifiedRedirectMiddleware(object):
                 new_location = list(parsed_location)
 
                 new_location[0] = 'https' if self.request_is_secure(request) else 'http'
-                new_location[1] = Site.objects.get_current().domain
+                new_location[1] = request.get_host()
                 new_location[2] = urlparse.urljoin(request.META['PATH_INFO'], parsed_location.path)
 
                 response['Location'] = urlparse.urlunparse(new_location)


### PR DESCRIPTION
I've add a method to `FullyQualifiedRedirectMiddleware` which sniffs the scheme from the request and then uses that instead of hardcoding it. It's pretty simple, and I stole the idea from django-sslify: https://github.com/rdegges/django-sslify. 

The basic idea is to rely on `request.is_secure()`, but I've added some extra smarts to deal with requests forwarded from a proxy too, which newer Djangos (>=1.4) deal with already, but older Djangos don't, since this is still used by mapumental on Django 1.3 from what I can see.

To use it, you don't need to add anything, but requests proxied won't be correctly identified unless you set `SECURE_PROXY_SSL_HEADER` as per: https://docs.djangoproject.com/en/1.4/ref/settings/#secure-proxy-ssl-header. Does this seem like a good idea?
