### PR TITLE
Implement unicode name normalization and transliteration in order not to...

### DIFF
--- a/rblib/format.rb
+++ b/rblib/format.rb
@@ -9,6 +9,8 @@
 # the tests in tests/format.rb should somehow made to run from
 # the foi app.
 require 'cgi'
+require 'unicode'
+require 'unidecode'
 
 module MySociety
     module Format
@@ -97,6 +99,9 @@ module MySociety
         # Simplified a name to something usable in a URL
         def Format.simplify_url_part(text, default_name, max_len = nil)
             text = text.downcase # this also clones the string, if we use downcase! we modify the original
+            text = Unicode.normalize_KD(text)
+            text = Unidecoder.decode(text).downcase
+
             text.gsub!(/(\s|-|_)/, "_")
             text.gsub!(/[^a-z0-9_]/, "")
             text.gsub!(/_+/, "_")

--- a/rblib/tests/format_test.rb
+++ b/rblib/tests/format_test.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 $:.push(File.join(File.dirname(__FILE__), '..'))
 require 'format'
 require 'test/unit'
@@ -47,6 +48,33 @@ information on our website at
 &lt;<a href='https://web.nhs.net/owa/redir.aspx?C=25a8af7e66054d62a435313f7f3d4694&amp;URL=http%3a%2f%2fwww.ico.gov.uk%2f'>https://web.nhs.net/owa/redir.aspx?C=25a8af7e66054d62a435313f7f3d4694&amp;URL=http%3a%2f%2fwww.ico.gov.uk%2f</a>&gt; <a href='http://www.ico.gov.uk'>www.ico.gov.uk</a>."""
     expect_clickable(text, expected)
 
+  end
+
+  def test_unicode_transliteration
+    default_name = 'body'
+    text = 'Državno sodišče'
+    expected = 'drzavno_sodisce'
+    assert MySociety::Format.simplify_url_part(text, default_name) == expected
+
+    text = 'Реактор Большой Мощности Канальный'
+    expected = 'rieaktor_bolshoi_moshchnosti_kanalnyi'
+    assert MySociety::Format.simplify_url_part(text, default_name) == expected
+
+    text = 'Prefeitura de Curuçá - PA '
+    expected = 'prefeitura_de_curuca_pa'
+    assert MySociety::Format.simplify_url_part(text, default_name) == expected
+
+    text = 'Prefeitura de Curuá - PA '
+    expected = 'prefeitura_de_curua_pa'
+    assert MySociety::Format.simplify_url_part(text, default_name) == expected
+
+    text = 'Prefeitura de Pirajuí - SP'
+    expected = 'prefeitura_de_pirajui_sp'
+    assert MySociety::Format.simplify_url_part(text, default_name) == expected
+
+    text = 'Siméon'
+    expected = 'simeon'
+    assert MySociety::Format.simplify_url_part(text, default_name) == expected
   end
 
 end


### PR DESCRIPTION
... omit accented or other non-ASCII characters from URLs. Requires unicode and unidecode.

Fixes issues:
https://github.com/opennorth/alaveteli/issues/2 
https://github.com/mysociety/alaveteli/issues/282
https://github.com/mysociety/alaveteli/issues/902

With tests. Tested and developed on ruby 1.9.1, would appreciate someone running tests on ruby 1.8.
