### PR TITLE
Add support for installing Alaveteli to install-site.sh

### DIFF
--- a/bin/install-site.sh
+++ b/bin/install-site.sh
@@ -475,7 +475,7 @@ install_website_packages() {
 }
 
 overwrite_rc_local() {
-    EC2_REWRITE="$REPOSITORY/bin/ec2-rewrite-conf"
+    EC2_REWRITE="$BIN_DIRECTORY/ec2-rewrite-conf"
     # Some scripts have an ec2-rewrite-conf script that can be used to
     # update the hostnme on reboot - if that's present, use it,
     # otherwise the alternative is to re-run the install script:


### PR DESCRIPTION
Along with changes in a separate pull request for Alaveteli,
these changes let you install Alaveteli using our standard
install script.

One change in behaviour is that the installation preserves
a copy of the script that when it's used, which means that
it can't be used when piped to `sudo sh -s`.  I've updated
all of our documentation to use separate invocations of
curl and the script, however.
