### PR TITLE
Pip setuptools issue

### DIFF
--- a/bin/get_pip.bash
+++ b/bin/get_pip.bash
@@ -7,7 +7,15 @@
 # https://github.com/pypa/pip/issues/1422
 #
 # We should be able to retire this script once we have upgraded from wheezy
-# to jessie
+# to jessie.
+
+# In the meantime, in the script which prepares your environment (often called
+# prepare_environment.bash), you need to run this script just after your
+# virtualenv is activated. If you have commonlib available, you can just run
+# the script, otherwise, use something like
+
+# curl -s https://raw.github.com/mysociety/commonlib/master/bin/get_pip.bash | bash
+
 
 # Upgrade pip to a secure version
 curl -s https://raw.github.com/pypa/pip/master/contrib/get-pip.py | python


### PR DESCRIPTION
With a small change to every Django site (sorry) this will get us past the problem with the latest pip where it requires a more recent setuptools than we can get.
