### PR TITLE
Prefer ./script over ./bin

### DIFF
--- a/bin/install-site.sh
+++ b/bin/install-site.sh
@@ -537,13 +537,18 @@ fi
 
 # Check that we can find the bin or script directory:
 if [ -d "$REPOSITORY/bin" ]
-then
-    BIN_DIRECTORY="$REPOSITORY/bin"
-elif [ -d "$REPOSITORY/script" ]
-then
-    BIN_DIRECTORY="$REPOSITORY/script"
-else
-    error_msg "No bin or script directory was found in $REPOSITORY"
+    then
+      BIN_DIRECTORY="$REPOSITORY/bin"
 fi
 
-. "$BIN_DIRECTORY/site-specific-install.sh"
+if [ -d "$REPOSITORY/script" ]
+    then
+      BIN_DIRECTORY="$REPOSITORY/script"
+fi
+
+if [ -f "$BIN_DIRECTORY/site-specific-install.sh" ]
+    then
+        . "$BIN_DIRECTORY/site-specific-install.sh"
+    else
+        error_msg "No bin or script directory was found in $REPOSITORY"
+fi


### PR DESCRIPTION
It is common for Ruby applications to have both a ./bin and ./script
directory.

This commit forces install-site.sh to prefer ./script over ./bin if both
exist, as this is where site-specific-install.sh lives in alaveteli.

We now only attempt to source the file if $BIN_DIRECTORY exists, and
fail gracefuly otherwise.
