### PR TITLE
Don't over look site-specific-install.sh in ./bin

### DIFF
--- a/bin/install-site.sh
+++ b/bin/install-site.sh
@@ -536,12 +536,12 @@ else
 fi
 
 # Check that we can find the bin or script directory:
-if [ -d "$REPOSITORY/bin" ]
+if [ -d "$REPOSITORY/bin" ] && [ -f "$REPOSITORY/bin/site-specific-install.sh" ]
     then
       BIN_DIRECTORY="$REPOSITORY/bin"
 fi
 
-if [ -d "$REPOSITORY/script" ]
+if [ -d "$REPOSITORY/script" ] && [ -f "$REPOSITORY/script/site-specific-install.sh" ]
     then
       BIN_DIRECTORY="$REPOSITORY/script"
 fi


### PR DESCRIPTION
The previous fix for #17 would break installation for repositories
where `site-specific-install.sh` existed in `./bin` but not `./script`, e.g.
FixMyStreet.

We now choose `$BIN_DIRECTORY` based on where `site-specific-install.sh`
actually is.
