### PR TITLE
Only set up default locale on FixMyStreet install.

### DIFF
--- a/bin/install-site.sh
+++ b/bin/install-site.sh
@@ -208,7 +208,7 @@ add_locale() {
 
 setup_locale() {
     echo "Setting up locale... "
-    default=$(LANG="" && source /etc/default/locale && echo $LANG)
+    default=$(LANG="" && . /etc/default/locale && echo $LANG)
     if [ x"$(LC_ALL=$LANG locale -k LC_CTYPE | grep -c 'charmap="UTF-8"')" = x1 ]; then
         # Current is UTF-8, make sure it's generated and use that
         add_locale $LANG


### PR DESCRIPTION
FixMyStreet uses the default locale in order to have working URIs with
floating point numbers. This could be moved to the FixMyStreet install
script with its next release and then removed from here.
