### PR TITLE
RFC: Change install directory when the app is default

### DIFF
--- a/bin/install-site.sh
+++ b/bin/install-site.sh
@@ -123,7 +123,7 @@ fi
 if [ $DEVELOPMENT_INSTALL = true ]; then
     DIRECTORY=$(cd "."; pwd)
 elif [ $DEFAULT_SERVER = true ]; then
-    DIRECTORY="/var/www/$SITE"
+    DIRECTORY="/var/www"
 else
     DIRECTORY="/var/www/$HOST"
 fi


### PR DESCRIPTION
When the application is installed as the default server, do not install
it in to `/var/www/$SITE/$SITE`.

When installing an app, I expect it to be installed in a $DIRECTORY with
the same name as the application underneath a $PREFIX. If the directory prefix
is `/var/www`, I'd expect the application files to reside in
`/var/www/APPLICATION_NAME`.

In the case of the application being the default server, create the
directory in the suggested way. The install script does write additional
files and directories to `/var/www`, but those can be moved to FSH
compliant locations in later commits.

`/var/www` also gets created as the application user, rather than root, but
that's fine since the application being installed is likely to be the only
application installed anyway, and this is not a special FSH directory.

In the case of the application being one of many, the directory tree
stays the same: `/var/www/$HOST/$SITE`. Arguably the application files
should just be installed directly inside `/var/www/$HOST`, but this is
less confusing and I think we should deal with one thing at a time.

This commit will affect application site-specific-install.sh scripts, so
ensure that any configuration files you generate have the correct path.
