### PR TITLE
Export noninteractive when installing website packages

### DIFF
--- a/bin/install-site.sh
+++ b/bin/install-site.sh
@@ -485,7 +485,8 @@ install_website_packages() {
     else
         PACKAGES_FILE="$GENERIC_PACKAGES"
     fi
-    xargs -a "$PACKAGES_FILE" apt-get -qq -y install >/dev/null
+    DEBIAN_FRONTEND=noninteractive \
+      xargs -a "$PACKAGES_FILE" apt-get -qq -y install >/dev/null
     echo "  $DONE_MSG"
 }
 


### PR DESCRIPTION
While working on the Alaveteli Wheezy install [1] an update of libc was
asking whether to restart services after the package upgrade so blocking
the script from continuing.

[1] https://github.com/mysociety/alaveteli/pull/1720

![](http://i.imgur.com/qFcEAY2.png)
