### PR TITLE
Add source encoding for all ruby files.

### DIFF
--- a/rblib/autorotate_image.rb
+++ b/rblib/autorotate_image.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # This is for rotating images to the right orientation based on the
 # EXIF orientation data.  It depends on the binary jhead from the
 # package jhead.

--- a/rblib/config.rb
+++ b/rblib/config.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # config.rb:
 # Very simple config parser. Our config files are sort of cod-PHP.
 #

--- a/rblib/debug_helpers.rb
+++ b/rblib/debug_helpers.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # debug_helpers.rb:
 # mySociety library of debugging functions.
 #

--- a/rblib/external_command.rb
+++ b/rblib/external_command.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# -*- encoding : utf-8 -*-
 # Run an external command, capturing its stdout and stderr streams into
 # variables, and returning some information about the way the process
 # exited.

--- a/rblib/format.rb
+++ b/rblib/format.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # format.rb:
 # mySociety library of formatting functions.
 #

--- a/rblib/git.rb
+++ b/rblib/git.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # This file contains wrappers for useful operations on git
 # repositories.
 

--- a/rblib/htmlentities.rb
+++ b/rblib/htmlentities.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'htmlentities/legacy'
 
 #

--- a/rblib/htmlentities/html4.rb
+++ b/rblib/htmlentities/html4.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class HTMLEntities
   MAPPINGS = {} unless defined? MAPPINGS
   MAPPINGS['html4'] = {

--- a/rblib/htmlentities/legacy.rb
+++ b/rblib/htmlentities/legacy.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class HTMLEntities
   class << self
     

--- a/rblib/htmlentities/string.rb
+++ b/rblib/htmlentities/string.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'htmlentities'
 
 #

--- a/rblib/htmlentities/xhtml1.rb
+++ b/rblib/htmlentities/xhtml1.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class HTMLEntities
   MAPPINGS = {} unless defined? MAPPINGS
   MAPPINGS['xhtml1'] = {

--- a/rblib/mapit.rb
+++ b/rblib/mapit.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # mapit.rb:
 # Client interface for MaPit
 #

--- a/rblib/mask.rb
+++ b/rblib/mask.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # mask.rb - text masking functions
 #
 # Copyright (c) 2010 UK Citizens Online Democracy. All rights reserved.

--- a/rblib/rabx.rb
+++ b/rblib/rabx.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # rabx.rb:
 # Client side functions to call RABX services, but via REST/JSON, rather than
 # using netstrings as for older Perl/PHP clients.

--- a/rblib/survey.rb
+++ b/rblib/survey.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # survey.rb
 # Client interface for survey.mysociety.org
 

--- a/rblib/tests/external_command_spec.rb
+++ b/rblib/tests/external_command_spec.rb
@@ -1,4 +1,4 @@
-# coding: utf-8
+# -*- encoding : utf-8 -*-
 # This is a test of the external_command library
 $:.push(File.join(File.dirname(__FILE__), '..'))
 

--- a/rblib/tests/format_test.rb
+++ b/rblib/tests/format_test.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# -*- encoding : utf-8 -*-
 $:.push(File.join(File.dirname(__FILE__), '..'))
 require 'format'
 require 'test/unit'

--- a/rblib/tests/mask_test.rb
+++ b/rblib/tests/mask_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 $:.push(File.join(File.dirname(__FILE__), '..'))
 require 'mask'
 require 'test/unit'

--- a/rblib/tests/survey_test.rb
+++ b/rblib/tests/survey_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 $:.push(File.join(File.dirname(__FILE__), '..'))
 require 'config'
 require 'survey'

--- a/rblib/tests/validate_test.rb
+++ b/rblib/tests/validate_test.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# -*- encoding : utf-8 -*-
 $:.push(File.join(File.dirname(__FILE__), '..'))
 require 'validate'
 require 'test/unit'

--- a/rblib/url_mapper.rb
+++ b/rblib/url_mapper.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # url_mapper.rb:
 #
 # Some functions for transforming relative URLs within an application

--- a/rblib/util.rb
+++ b/rblib/util.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # util.rb:
 # mySociety library of general utility functions
 #

--- a/rblib/validate.rb
+++ b/rblib/validate.rb
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- encoding : utf-8 -*-
 # validate.rb:
 # mySociety library of validation functions, such as valid email address.
 #

--- a/rblib/voting_area.rb
+++ b/rblib/voting_area.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # voting_area.rb - voting area definitions.
 #
 # Copyright (c) 2010 UK Citizens Online Democracy. All rights reserved.


### PR DESCRIPTION
This is important under ruby 1.9 in order to determine the
encoding that will be used for new strings created in the code in
the file.