### PR TITLE
Fix the upgrade of setuptools (broken since pip 7.0.0)

### DIFF
--- a/bin/get_pip.bash
+++ b/bin/get_pip.bash
@@ -20,5 +20,8 @@
 # Upgrade pip to a secure version
 curl -s -L https://raw.github.com/pypa/pip/master/contrib/get-pip.py | python
 
-# The latest pip requires a newer version of setuptools than we have
-pip install setuptools --no-use-wheel --upgrade
+# The latest pip requires a newer version of setuptools than we have.
+# Since pip version 7.0.0 you can upgrade to the latest version of
+# setuptools by upgrading distribute; for details of this change see
+# https://pip.pypa.io/en/latest/news.html
+pip install distribute --no-use-wheel --upgrade


### PR DESCRIPTION
Since pip 7.0.0, get_pip.bash was failing to upgrade setuptools, the
most obvious symptom of which was lots of "invalid command 'bdist_wheel'"
errors.  This commit switches the command to upgrade setuptools to the
one now suggested in the pip changelog.