### PR TITLE
add hint that config permission problem is likely due to wrong user

### DIFF
--- a/perllib/mySociety/Config.pm
+++ b/perllib/mySociety/Config.pm
@@ -78,7 +78,7 @@ sub read_config_from_php($) {
     my ($f) = @_;
 
     if (! -r $f) {
-        throw Error::Simple "$f: read permissions not OK for config file";
+        throw Error::Simple "$f: permission denied trying to read config file (maybe you're not running as the correct user?)";
     }
 
     my $old_SIGCHLD = $SIG{CHLD};


### PR DESCRIPTION
see #40 for user running fixmystreet not as 'fms' user for example,
so I'm suggesting rewording error message to make it clear this
mightn't be a problem with the config file itself