### PR TITLE
Fallback to generic package files if present.

### DIFF
--- a/bin/install-site.sh
+++ b/bin/install-site.sh
@@ -498,6 +498,8 @@ install_sysvinit_script() {
 install_website_packages() {
     echo "Installing packages from repository packages file... "
     EXACT_PACKAGES="$CONF_DIRECTORY/packages.$DISTRIBUTION-$DISTVERSION"
+    DIST_PACKAGES="$CONF_DIRECTORY/packages.$DISTRIBUTION"
+    FALLBACK_PACKAGES="$CONF_DIRECTORY/packages.generic"
     PRECISE_PACKAGES="$CONF_DIRECTORY/packages.ubuntu-precise"
     SQUEEZE_PACKAGES="$CONF_DIRECTORY/packages.debian-squeeze"
     GENERIC_PACKAGES="$CONF_DIRECTORY/packages"
@@ -505,6 +507,14 @@ install_website_packages() {
     if [ -e "$EXACT_PACKAGES" ]
     then
         PACKAGES_FILE="$EXACT_PACKAGES"
+    # Otherwise, if there's a file for the distribution:
+    elif [ -e "$DIST_PACKAGES" ]
+    then
+        PACKAGES_FILE="$DIST_PACKAGES"
+    # Or, if there's a fallback generic file:
+    elif [ -e "$FALLBACK_PACKAGES" ]
+    then
+        PACKAGES_FILE="$FALLBACK_PACKAGES"
     # Otherwise, if this is Ubuntu, and there's a version specifically
     # for precise, use that:
     elif [ x"$DISTRIBUTION" = x"ubuntu" ] && [ -e "$PRECISE_PACKAGES" ]

--- a/bin/install-site.sh
+++ b/bin/install-site.sh
@@ -502,7 +502,6 @@ install_website_packages() {
     FALLBACK_PACKAGES="$CONF_DIRECTORY/packages.generic"
     PRECISE_PACKAGES="$CONF_DIRECTORY/packages.ubuntu-precise"
     SQUEEZE_PACKAGES="$CONF_DIRECTORY/packages.debian-squeeze"
-    GENERIC_PACKAGES="$CONF_DIRECTORY/packages"
     # If there's an exact match for the distribution and release, use that:
     if [ -e "$EXACT_PACKAGES" ]
     then
@@ -526,7 +525,8 @@ install_website_packages() {
     then
         PACKAGES_FILE="$SQUEEZE_PACKAGES"
     else
-        PACKAGES_FILE="$GENERIC_PACKAGES"
+        error_msg "Could not find a packages file to use - please contribute one."
+        exit 1
     fi
     DEBIAN_FRONTEND=noninteractive \
       xargs -a "$PACKAGES_FILE" apt-get -qq -y install >/dev/null


### PR DESCRIPTION
This allows a codebase to use e.g. packages.ubuntu and/or
packages.generic to supply a list of packages to install,
rather than assuming it can use ubuntu-precise on Ubuntu,
or debian-squeeze on Debian.

Also fixes #25 