### PR TITLE
Add MAPIT_API_KEY config key support

### DIFF
--- a/perllib/mySociety/MaPit.pm
+++ b/perllib/mySociety/MaPit.pm
@@ -37,6 +37,9 @@ sub _call ($$;$) {
     unless ($ua) {
         $ua = new LWP::UserAgent();
         $ua->agent("MaPit.pm web service client");
+        if (my $api_key = mySociety::Config::get('MAPIT_API_KEY')) {
+            $ua->default_header("X-Api-Key", $api_key);
+        }
     }
     configure() unless $base;
     $params = join(',', @$params) if ref $params;


### PR DESCRIPTION
If the MapIt you're using requires an API key, you can specify it in your
general.yml config with MAPIT_API_KEY and it'll be included in the X-Api-Key
header in requests to MapIt.