### PR TITLE
Ignore hostname resolution error during install-site

### DIFF
--- a/bin/install-site.sh
+++ b/bin/install-site.sh
@@ -177,7 +177,7 @@ IP_ADDRESS_FOR_HOST="$(dig +short $HOST)"
 if [ x = x"$IP_ADDRESS_FOR_HOST" ]
 then
     error_msg "The hostname $HOST didn't resolve to an IP address"
-    exit 1
+    # exit 1
 fi
 echo $DONE_MSG
 


### PR DESCRIPTION
A topic for discussion!

As you can see from https://github.com/mysociety/alaveteli/pull/4522, I had some issues when privisioning an Alaveteli Vagrant VM, because this `exit` line in `install-site.sh` was causing the provisioner to bail out.

![screen shot 2018-02-13 at 12 54 37](https://user-images.githubusercontent.com/739624/36150913-3c26e65e-10bd-11e8-8fc2-0192f278dd7c.png)

Does anyone know why this hostname check is performed?