### PR TITLE
MapIt API key support/simplejson removal

### DIFF
--- a/pylib/mysociety/mapit.py
+++ b/pylib/mysociety/mapit.py
@@ -7,6 +7,9 @@
 # $Id: mapit.py,v 1.2 2009-11-30 13:11:03 matthew Exp $
 #
 
+import urllib2
+import urlparse
+
 import mysociety.config
 import mysociety.rabx
 
@@ -54,3 +57,12 @@ def get_location(postcode, partial = None):
     result = call_old('get_location', postcode, partial)
     return result
 
+def call(url):
+    full_url = urlparse.urljoin(mysociety.config.get('MAPIT_URL'), url)
+    api_key = mysociety.config.get('MAPIT_API_KEY', '')
+    if api_key:
+        headers = {'X-Api-Key': api_key}
+    else:
+        headers = {}
+    request = urllib2.Request(full_url, headers=headers)
+    return urllib2.urlopen(request)

--- a/pylib/mysociety/mapit.py
+++ b/pylib/mysociety/mapit.py
@@ -11,51 +11,6 @@ import urllib2
 import urlparse
 
 import mysociety.config
-import mysociety.rabx
-
-def call_old(*params):
-    base_url = mysociety.config.get("MAPIT_URL")
-    return mysociety.rabx.call_rest_rabx(base_url, params)
-
-BAD_POSTCODE = 2001        #    String is not in the correct format for a postcode. 
-POSTCODE_NOT_FOUND = 2002        #    The postcode was not found in the database. 
-AREA_NOT_FOUND = 2003        #    The area ID refers to a non-existent area. 
-
-def get_voting_areas(postcode):
-    result = call_old('get_voting_areas', postcode)
-    return result
-
-def get_voting_area_info(area):
-    result = call_old('get_voting_area_info', area)
-    return result
-
-def get_voting_areas_info(ary):
-    result = call_old('get_voting_areas_info', ary)
-    return result
-
-def get_voting_area_by_name(name, type = None, min_generation = None):
-    result = call_old('get_voting_area_by_name', name, type, min_generation)
-    return result
-
-def get_voting_areas_by_location(coordinate, method, types = None, generation = None):
-    result = call_old('get_voting_areas_by_location', coordinate, method, types, generation)
-    return result
-
-def get_areas_by_type(type, min_generation = None):
-    result = call_old('get_areas_by_type', type, min_generation)
-    return result
-
-def get_example_postcode(id):
-    result = call_old('get_example_postcode', id)
-    return result
-
-def get_voting_area_children(id):
-    result = call_old('get_voting_area_children', id)
-    return result
-
-def get_location(postcode, partial = None):
-    result = call_old('get_location', postcode, partial)
-    return result
 
 def call(url):
     full_url = urlparse.urljoin(mysociety.config.get('MAPIT_URL'), url)

--- a/pylib/mysociety/rabx.py
+++ b/pylib/mysociety/rabx.py
@@ -12,8 +12,11 @@
 import os
 import subprocess
 import re
-import simplejson
 import urllib
+try:
+    import json
+except ImportError:
+    import simplejson as json
 
 class RABXException(Exception):
     def __init__(self, value, text, extradata):
@@ -38,7 +41,7 @@ def call_rest_rabx(base_url, params_init):
     params_joined = "/".join(params_quoted)
     url = base_url.replace(".cgi", "-rest.cgi") + "?" + params_joined
     content = urllib.urlopen(url).read()
-    result = simplejson.loads(content)
+    result = json.loads(content)
     if 'error_value' in result:
         raise RABXException(result['error_value'], result['error_text'], result.get('error_extradata'))
     return result


### PR DESCRIPTION
A couple of bits that came as a result of the Mapumental TNDS timetable work:

 - New mapit.call_mapit function that adds API key to request
 - Prefer Python's standard library `json` module over `simplejson`