### PR TITLE
Systemd compatibility

### DIFF
--- a/bin/install-site-core.sh
+++ b/bin/install-site-core.sh
@@ -12,7 +12,7 @@
 
 # The usage is:
 #
-#   install-site.sh [--dev] [--default] [--docker] SITE-NAME UNIX-USER [HOST]
+#   install-site.sh [--dev] [--default] [--systemd] [--docker] SITE-NAME UNIX-USER [HOST]
 #
 # ... where --default means to install as the default site for this
 # server, rather than a virtualhost for HOST.  HOST is only optional
@@ -21,6 +21,9 @@
 # --dev will work from a checkout of the repository in your current directory,
 # (it will check it out if not present, do nothing if it is), and will be
 # passed down to site specific scripts so they can e.g. not install nginx.
+#
+# --systemd will check for and use a native systemd unit file if a suitable
+# template is provided in the source repository.
 #
 # --docker will set some further variables (including --default) to prevent
 # installing additional software into the image.
@@ -62,6 +65,13 @@ then
     shift
 fi
 
+SYSTEMD=false
+if [ x"$1" = x"--systemd" ]
+then
+    SYSTEMD=true
+    shift
+fi
+
 DOCKER=false
 INSTALL_DB=true
 INSTALL_POSTFIX=true
@@ -75,13 +85,14 @@ fi
 
 usage_and_exit() {
     cat >&2 <<EOUSAGE
-Usage: $0 [--dev] [--default] [--docker] <SITE-NAME> <UNIX-USER> [HOST]
+Usage: $0 [--dev] [--default] [--docker] [--systemd] <SITE-NAME> <UNIX-USER> [HOST]
 HOST is only optional if you are running this on an EC2 instance.
 --default means to install as the default site for this server,
 rather than a virtualhost for HOST.
 --dev sets things up for a local development environment.
 --docker is intended when running this script from a Dockerfile and
 sets a number of other local variables controlling behaviour.
+--systemd try and use a native systemd unit file rather than a sysvinit script.
 EOUSAGE
     exit 1
 }

--- a/bin/install-site.sh
+++ b/bin/install-site.sh
@@ -374,7 +374,7 @@ add_website_to_nginx() {
     fi
     ln -nsf "$NGINX_SITE_FILENAME" "$NGINX_SITE_LINK"
     make_log_directory
-    /etc/init.d/nginx restart >/dev/null
+    /usr/sbin/service nginx restart >/dev/null
     echo $DONE_MSG
 }
 
@@ -397,7 +397,7 @@ install_sysvinit_script() {
     fi
     if [ ! "$DOCKER" = true ]; then
         # We don't want to try and start services during the build.
-        /sbin/service $SITE restart
+        /usr/sbin/service $SITE restart
     fi
 }
 
@@ -454,7 +454,7 @@ overwrite_rc_local() {
 #!/bin/sh -e
 
 su -l -c '$EC2_REWRITE' $UNIX_USER
-/etc/init.d/$SITE restart
+/usr/sbin/service $SITE restart
 
 exit 0
 EOF

--- a/shlib/installfns
+++ b/shlib/installfns
@@ -374,7 +374,7 @@ add_website_to_nginx() {
     fi
     ln -nsf "$NGINX_SITE_FILENAME" "$NGINX_SITE_LINK"
     make_log_directory
-    /etc/init.d/nginx restart >/dev/null
+    /usr/sbin/service nginx restart >/dev/null
     echo $DONE_MSG
 }
 
@@ -397,7 +397,7 @@ install_sysvinit_script() {
     fi
     if [ ! "$DOCKER" = true ]; then
         # We don't want to try and start services during the build.
-        /sbin/service $SITE restart
+        /usr/sbin/service $SITE restart
     fi
 }
 
@@ -454,7 +454,7 @@ overwrite_rc_local() {
 #!/bin/sh -e
 
 su -l -c '$EC2_REWRITE' $UNIX_USER
-/etc/init.d/$SITE restart
+/usr/sbin/service $SITE restart
 
 exit 0
 EOF

--- a/shlib/installfns
+++ b/shlib/installfns
@@ -379,19 +379,25 @@ add_website_to_nginx() {
 }
 
 install_sysvinit_script() {
-    SYSVINIT_FILENAME=/etc/init.d/$SITE
-    if [ "$DOCKER" = true ] && [ -e $CONF_DIRECTORY/sysvinit.docker.example ]; then
-        cp $CONF_DIRECTORY/sysvinit.docker.example $SYSVINIT_FILENAME
+    if [ "$SYSTEMD" = true ] && [ -e $CONF_DIRECTORY/systemd.example ]; then
+      INIT_FILENAME=/etc/systemd/system/${SITE}.service
+      cp $CONF_DIRECTORY/systemd.example $INIT_FILENAME
     else
-        cp $CONF_DIRECTORY/sysvinit.example $SYSVINIT_FILENAME
+      INIT_FILENAME=/etc/init.d/$SITE
+      cp $CONF_DIRECTORY/sysvinit.example $INIT_FILENAME
     fi
-    sed -i "s,/var/www/$SITE,$DIRECTORY,g" $SYSVINIT_FILENAME
-    sed -i "s/^ *USER=.*/USER=$UNIX_USER/" $SYSVINIT_FILENAME
-    chmod a+rx $SYSVINIT_FILENAME
-    update-rc.d $SITE defaults
+    sed -i "s,/var/www/$SITE,$DIRECTORY,g" $INIT_FILENAME
+    sed -i "s/^ *\(U[Ss][Ee][Rr]\)=.*/\1=$UNIX_USER/" $INIT_FILENAME
+    if [ "$SYSTEMD" = true ] && [ -e $CONF_DIRECTORY/systemd.example ]; then
+      /bin/systemctl daemon-reload
+      /bin/systemctl enable $SITE
+    else
+      chmod a+rx $INIT_FILENAME
+      update-rc.d $SITE defaults
+    fi
     if [ ! "$DOCKER" = true ]; then
         # We don't want to try and start services during the build.
-        /etc/init.d/$SITE restart
+        /sbin/service $SITE restart
     fi
 }
 


### PR DESCRIPTION
This adds support for using native systemd unit file templates, if available and asked for. It also ensures that any service management commands are compatible with both sysvinit and systemd.