### PR TITLE
Remove dependency on unicode gem

### DIFF
--- a/rblib/format.rb
+++ b/rblib/format.rb
@@ -10,7 +10,6 @@
 # the tests in tests/format.rb should somehow made to run from
 # the foi app.
 require 'cgi'
-require 'unicode'
 require 'unidecoder'
 
 module MySociety
@@ -124,7 +123,7 @@ module MySociety
         # Simplified a name to something usable in a URL
         def self.simplify_url_part(text, default_name, max_len = nil)
             text = text.downcase # this also clones the string, if we use downcase! we modify the original
-            text = Unicode.normalize_KD(text)
+            text = text.unicode_normalize(:nfkd)
             text = text.to_ascii.downcase
 
             text.gsub!(/(\s|-|_)/, "_")


### PR DESCRIPTION
Switch to core `#unicode_normalize` method, this has been present in
Ruby standard library since v2.2.