### PR TITLE
Change Debian mirror

### DIFF
--- a/bin/install-site.sh
+++ b/bin/install-site.sh
@@ -156,8 +156,8 @@ update_apt_sources() {
         # Install the basic packages we require:
         cat > /etc/apt/sources.list.d/mysociety-extra.list <<EOF
 # Debian mirror to use, including contrib and non-free:
-deb http://the.earth.li/debian/ ${DISTVERSION} main contrib non-free
-deb-src http://the.earth.li/debian/ ${DISTVERSION} main contrib non-free
+deb http://mirror.mythic-beasts.com/debian/ ${DISTVERSION} main contrib non-free
+deb-src http://mirror.mythic-beasts.com/debian/ ${DISTVERSION} main contrib non-free
 
 # Security Updates:
 deb http://security.debian.org/ ${DISTVERSION}/updates main contrib non-free

--- a/shlib/installfns
+++ b/shlib/installfns
@@ -156,8 +156,8 @@ update_apt_sources() {
         # Install the basic packages we require:
         cat > /etc/apt/sources.list.d/mysociety-extra.list <<EOF
 # Debian mirror to use, including contrib and non-free:
-deb http://the.earth.li/debian/ ${DISTVERSION} main contrib non-free
-deb-src http://the.earth.li/debian/ ${DISTVERSION} main contrib non-free
+deb http://mirror.mythic-beasts.com/debian/ ${DISTVERSION} main contrib non-free
+deb-src http://mirror.mythic-beasts.com/debian/ ${DISTVERSION} main contrib non-free
 
 # Security Updates:
 deb http://security.debian.org/ ${DISTVERSION}/updates main contrib non-free


### PR DESCRIPTION
The old mirror only has amd64 packages, the new mirror includes other
architectures, such as arm64, which would be required for
https://github.com/mysociety/alaveteli/pull/6538