### PR TITLE
Add GNU Privacy Guard to core packages

### DIFF
--- a/bin/install-site.sh
+++ b/bin/install-site.sh
@@ -17,7 +17,7 @@ core_package_install() {
     apt-get -qq update
     echo $DONE_MSG
     echo "Installing some core packages..."
-    for package in apt-utils git locales lockfile-progs curl dnsutils lsb-release; do
+    for package in apt-utils git locales lockfile-progs curl dnsutils lsb-release gnupg; do
         echo -n "  $package... "; apt-get -qq install -y $package >/dev/null; echo $DONE_MSG
     done
 }

--- a/shlib/installfns
+++ b/shlib/installfns
@@ -17,7 +17,7 @@ core_package_install() {
     apt-get -qq update
     echo $DONE_MSG
     echo "Installing some core packages..."
-    for package in apt-utils git locales lockfile-progs curl dnsutils lsb-release; do
+    for package in apt-utils git locales lockfile-progs curl dnsutils lsb-release gnupg; do
         echo -n "  $package... "; apt-get -qq install -y $package >/dev/null; echo $DONE_MSG
     done
 }


### PR DESCRIPTION
Required for installing on Bullseye. Without this, for Alaveteli, we see
an error:
```
  Updating mySociety APT source...
  E: gnupg, gnupg2 and gnupg1 do not seem to be installed
```

We can't add to our site specific packages as these installed after the
repos have been updated.

While we could install prior to the install script invocation in our
Vagrantfile this wouldn't allow production installs and it seems like
other sites will also require this to get pass APT update.