### PR TITLE
Switch default database connection sslmode from allow to prefer

### DIFF
--- a/perllib/mySociety/DBHandle.pm
+++ b/perllib/mySociety/DBHandle.pm
@@ -118,7 +118,7 @@ sub new_dbh () {
         if (exists($mySociety::DBHandle::conf{Host}));
     $connstr .= ";port=$mySociety::DBHandle::conf{Port}"
         if (exists($mySociety::DBHandle::conf{Port}));
-    $connstr .= ";sslmode=allow";
+    $connstr .= ";sslmode=prefer";
     my $dbh = DBI->connect($connstr,
                         $mySociety::DBHandle::conf{User},
                         $mySociety::DBHandle::conf{Password}, {

--- a/perllib/mySociety/Dress.pm
+++ b/perllib/mySociety/Dress.pm
@@ -12,7 +12,7 @@ use strict;
 use mySociety::Config;
 
 # Dress DB - need to make DBHandle DBHandles?
-my $connstr = 'dbi:Pg:dbname=' . mySociety::Config::get('DRESS_DB_NAME') .';sslmode=allow';
+my $connstr = 'dbi:Pg:dbname=' . mySociety::Config::get('DRESS_DB_NAME') .';sslmode=prefer';
 $connstr .= ";host=" . mySociety::Config::get('DRESS_DB_HOST')
     if (mySociety::Config::get('DRESS_DB_HOST'));
 $connstr .= ";port=" . mySociety::Config::get('DRESS_DB_PORT')

--- a/phplib/db.php
+++ b/phplib/db.php
@@ -80,7 +80,7 @@ function db_connect() {
         if (defined("OPTION_${prefix}_DB_$v"))
             $connstr .= " $k='" .  constant("OPTION_${prefix}_DB_$v") . "'";
     }
-    $connstr .= " connect_timeout=10 sslmode=allow";
+    $connstr .= " connect_timeout=10 sslmode=prefer";
 
     /*  set 'persistent' => true to get persistent DB connections. 
      *  TODO: ensure


### PR DESCRIPTION
An `sslmode` of `allow` will first try an unencrypted connection before falling back to an encrypted one should that fail. `prefer` is the opposite behaviour and a more secure default, so let's use that instead.

Ideally this would be configurable, but with this change any connection errors logged by PostgreSQL will indicate that SSL isn't configured which is more useful information that indicating that it is enforced.