### PR TITLE
Update MapIt query string separator for PHP and Ruby

### DIFF
--- a/perllib/mySociety/MaPit.pm
+++ b/perllib/mySociety/MaPit.pm
@@ -56,8 +56,7 @@ sub call ($$;%) {
         $opts{URL} = $params;
     }
 
-    my $sep = mySociety::Config::get('MAPIT_API_SEPARATOR', ';');
-    my $qs = join $sep, map { $_ . '=' . get_opts_str($opts{$_}) } keys %opts;
+    my $qs = join '&', map { $_ . '=' . get_opts_str($opts{$_}) } keys %opts;
 
     my $r;
     $qs = encode_utf8($qs) if utf8::is_utf8($qs);

--- a/phplib/mapit.php
+++ b/phplib/mapit.php
@@ -54,7 +54,7 @@ function mapit_call($url, $params, $opts = array(), $errors = array()) {
     foreach ($opts as $k => $v) {
         if (!$v) continue;
         if (is_array($v)) $v = join(',', $v);
-        $qs .= $qs ? ';' : '';
+        $qs .= $qs ? '&' : '';
         $qs .= rawurlencode($k) . '=' . rawurlencode($v);
     }
     if (strlen(OPTION_MAPIT_URL . $urlp) > 1024) {

--- a/rblib/mapit.rb
+++ b/rblib/mapit.rb
@@ -220,11 +220,11 @@ module MySociety
         url_path += "/#{params}" if params
         url_path += "/#{suffix}" if suffix
         
-        # assemble a ";" delimited query string
+        # assemble a "&" delimited query string
         query_string = options.map do |key, value|
           value = value.join(',') if value.is_a? Array
           "#{key}=#{value}"
-        end.join(";")
+        end.join("&")
         
         # Use POST if the GET url would be too long
         if "#{base_url}#{url_path}".size > max_url_length


### PR DESCRIPTION
This was hardcoded to `;` but due to [changes in Python](https://github.com/python/cpython/commit/c9f07813ab8e664d8c34413c4fc2d4f86c061a92) MapIt will now only accept `&`.

@davea changed the Perl version in https://github.com/mysociety/commonlib/commit/c919d59dddaef90cb5521c4e9607181513e58d45 and retained the current default of `;` while allowing it to be overridden via `MAPIT_API_SEPARATOR`.

I think switching the default to `&` would seem a simpler solution - this should be backwards compatible as this has always been a valid separator, so unless there's something I misunderstand about the prior reasons for using `;` instead of `&` I can't really see why we wouldn't do this (although I'm generally in favour of being conservative about changing defaults, I'm also in favour of avoiding unecessary configuration variables - and in this case we're going to need to set this everywhere, so it may as well be a default).

So we could add a commit to update the Perl library, too, if agreed.