### PR TITLE
Add Bullseye backport repo

### DIFF
--- a/bin/install-site.sh
+++ b/bin/install-site.sh
@@ -151,7 +151,7 @@ update_apt_sources() {
                 SECURITY="$DISTVERSION/updates"
                 ;;
             bullseye)
-                BACKPORTS=false
+                BACKPORTS=true
                 SECURITY="$DISTVERSION-security"
                 ;;
             *)


### PR DESCRIPTION
Required for https://github.com/mysociety/alaveteli/pull/7575 to get Redis 6.2+.