### PR TITLE
[Ruby] restore ENV after calling external command

### DIFF
--- a/rblib/external_command.rb
+++ b/rblib/external_command.rb
@@ -94,6 +94,9 @@ class ExternalCommand
             Process.setrlimit(Process::RLIMIT_AS, @memory_limit, @default_memory_limit)
         end
 
+        # Store current environment variables before being overridden
+        old_env_values = @env.keys.inject({}) { |m, k| m[k] = ENV[k]; m }
+
         # Override the environment as specified
         ENV.update @env
 
@@ -128,6 +131,9 @@ class ExternalCommand
             # Restore the original memory limit
             Process.setrlimit(Process::RLIMIT_AS, @default_memory_limit)
         end
+
+        # Reset overridden environment variables
+        ENV.update(old_env_values)
 
         # if we're not expecting binary output, convert the output streams to the
         # default encoding now they are written to - not before, as there might be

--- a/rblib/tests/external_command_spec.rb
+++ b/rblib/tests/external_command_spec.rb
@@ -76,6 +76,14 @@ describe "when running ExternalCommand" do
         f.out.should =~ /^FOO=barbie$/
     end
 
+    it "should restore original environment variable" do
+        ENV["FOO"] = "frumious"
+        args = [env_cmd, { :stdin_string => "Here we are\nThis part will be ignored",
+                           :env => { "FOO" => "barbie" } }]
+        ExternalCommand.new(*args).run
+        ENV["FOO"].should == "frumious"
+    end
+
     it "should handle timeouts" do
         start_time = Time.now
         f = ExternalCommand.new(sleep_cmd, "30", :timeout => 2).run


### PR DESCRIPTION
We can't permanently change the ENV otherwise we'll get flaky specs.

This is the cause of broken specs for:
https://github.com/mysociety/alaveteli/pull/7843