### PR TITLE
Update APT formats supported operating systems

### DIFF
--- a/bin/install-site-core.sh
+++ b/bin/install-site-core.sh
@@ -175,5 +175,5 @@ update_apt_sources
 # Remove one crippling package, if it's installed:
 apt-get -qq remove -y --purge apt-xapian-index >/dev/null || true
 clone_or_update_repository
-chown -R "$UNIX_USER"."$UNIX_USER" "$DIRECTORY"
+chown -R "$UNIX_USER":"$UNIX_USER" "$DIRECTORY"
 run_site_specific_script

--- a/bin/install-site.sh
+++ b/bin/install-site.sh
@@ -132,7 +132,7 @@ update_apt_sources() {
     echo -n "Updating APT sources... "
     if [ x"$DISTRIBUTION" = x"ubuntu" ] ; then
         case "$DISTVERSION" in
-            xenial|bionic|focal)
+            focal|jammy)
                 : # Do nothing, these should have everything.
                 ;;
             *)
@@ -141,15 +141,15 @@ update_apt_sources() {
         esac
     elif [ x"$DISTRIBUTION" = x"debian" ] ; then
         case "$DISTVERSION" in
-            stretch)
-                BACKPORTS=true
-                SECURITY="$DISTVERSION/updates"
-                ;;
             buster)
                 BACKPORTS=false
                 SECURITY="$DISTVERSION/updates"
                 ;;
             bullseye)
+                BACKPORTS=false
+                SECURITY="$DISTVERSION-security"
+                ;;
+            bookworm)
                 BACKPORTS=false
                 SECURITY="$DISTVERSION-security"
                 ;;
@@ -189,7 +189,7 @@ update_mysociety_apt_sources() {
     # We build packages targetted at Debian releases.
     # Try and select the most appropritate ones for Ubuntu.
     case "$DISTVERSION" in
-        xenial|stretch|bionic|buster|focal|bullseye)
+        focal|jammy|buster|bullseye|bookworm)
             cat > /etc/apt/sources.list.d/mysociety-debian.list <<EOF
 deb http://debian.mysociety.org $DISTVERSION main
 EOF
@@ -386,8 +386,6 @@ install_website_packages() {
     EXACT_PACKAGES="$CONF_DIRECTORY/packages.$DISTRIBUTION-$DISTVERSION"
     DIST_PACKAGES="$CONF_DIRECTORY/packages.$DISTRIBUTION"
     FALLBACK_PACKAGES="$CONF_DIRECTORY/packages.generic"
-    PRECISE_PACKAGES="$CONF_DIRECTORY/packages.ubuntu-precise"
-    SQUEEZE_PACKAGES="$CONF_DIRECTORY/packages.debian-squeeze"
     # Allow override by setting PACKAGE_SUFFIX
     if [ -n "$PACKAGE_SUFFIX" ] && [ -e "$CONF_DIRECTORY/packages.$PACKAGE_SUFFIX" ]; then
         PACKAGES_FILE="$CONF_DIRECTORY/packages.$PACKAGE_SUFFIX"
@@ -403,16 +401,6 @@ install_website_packages() {
     elif [ -e "$FALLBACK_PACKAGES" ]
     then
         PACKAGES_FILE="$FALLBACK_PACKAGES"
-    # Otherwise, if this is Ubuntu, and there's a version specifically
-    # for precise, use that:
-    elif [ x"$DISTRIBUTION" = x"ubuntu" ] && [ -e "$PRECISE_PACKAGES" ]
-    then
-        PACKAGES_FILE="$PRECISE_PACKAGES"
-    # Otherwise, if this is Debian, and there's a version specifically
-    # for squeeze, use that:
-    elif [ x"$DISTRIBUTION" = x"debian" ] && [ -e "$SQUEEZE_PACKAGES" ]
-    then
-        PACKAGES_FILE="$SQUEEZE_PACKAGES"
     else
         error_msg "Could not find a packages file to use - please contribute one."
         exit 1

--- a/bin/install-site.sh
+++ b/bin/install-site.sh
@@ -136,8 +136,7 @@ update_apt_sources() {
                 : # Do nothing, these should have everything.
                 ;;
             *)
-                error_msg "Unsupported distribution and version combination $DISTRIBUTION $DISTVERSION"
-                exit 1
+                notice_msg "Unsupported distribution and version combination $DISTRIBUTION $DISTVERSION"
                 ;;
         esac
     elif [ x"$DISTRIBUTION" = x"debian" ] ; then
@@ -155,8 +154,7 @@ update_apt_sources() {
                 SECURITY="$DISTVERSION-security"
                 ;;
             *)
-                error_msg "Unsupported distribution and version combination $DISTRIBUTION $DISTVERSION"
-                exit 1
+                notice_msg "Unsupported distribution and version combination $DISTRIBUTION $DISTVERSION"
                 ;;
         esac
         # Install the basic packages we require:
@@ -179,8 +177,7 @@ deb-src http://http.debian.net/debian ${DISTVERSION}-backports main contrib non-
 EOF
         fi
     else
-        error_msg "Unsupported distribution and version combination $DISTRIBUTION $DISTVERSION"
-        exit 1
+        notice_msg "Unsupported distribution and version combination $DISTRIBUTION $DISTVERSION"
     fi
     apt-get -qq update
     echo $DONE_MSG
@@ -202,8 +199,7 @@ EOF
             echo $DONE_MSG
             ;;
         *)
-            error_msg "Unsupported distribution and version combination $DISTRIBUTION $DISTVERSION"
-            exit 1
+            notice_msg "Unsupported distribution and version combination $DISTRIBUTION $DISTVERSION, not adding mySociety repository."
             ;;
     esac
 }

--- a/bin/install-site.sh
+++ b/bin/install-site.sh
@@ -337,7 +337,7 @@ install_postgis() {
 make_log_directory() {
     LOG_DIRECTORY="$DIRECTORY/logs"
     mkdir -p "$LOG_DIRECTORY"
-    chown -R "$UNIX_USER"."$UNIX_USER" "$LOG_DIRECTORY"
+    chown -R "$UNIX_USER":"$UNIX_USER" "$LOG_DIRECTORY"
 }
 
 add_website_to_nginx() {
@@ -669,5 +669,5 @@ update_apt_sources
 # Remove one crippling package, if it's installed:
 apt-get -qq remove -y --purge apt-xapian-index >/dev/null || true
 clone_or_update_repository
-chown -R "$UNIX_USER"."$UNIX_USER" "$DIRECTORY"
+chown -R "$UNIX_USER":"$UNIX_USER" "$DIRECTORY"
 run_site_specific_script

--- a/shlib/installfns
+++ b/shlib/installfns
@@ -132,7 +132,7 @@ update_apt_sources() {
     echo -n "Updating APT sources... "
     if [ x"$DISTRIBUTION" = x"ubuntu" ] ; then
         case "$DISTVERSION" in
-            xenial|bionic|focal)
+            focal|jammy)
                 : # Do nothing, these should have everything.
                 ;;
             *)
@@ -141,15 +141,15 @@ update_apt_sources() {
         esac
     elif [ x"$DISTRIBUTION" = x"debian" ] ; then
         case "$DISTVERSION" in
-            stretch)
-                BACKPORTS=true
-                SECURITY="$DISTVERSION/updates"
-                ;;
             buster)
                 BACKPORTS=false
                 SECURITY="$DISTVERSION/updates"
                 ;;
             bullseye)
+                BACKPORTS=false
+                SECURITY="$DISTVERSION-security"
+                ;;
+            bookworm)
                 BACKPORTS=false
                 SECURITY="$DISTVERSION-security"
                 ;;
@@ -189,7 +189,7 @@ update_mysociety_apt_sources() {
     # We build packages targetted at Debian releases.
     # Try and select the most appropritate ones for Ubuntu.
     case "$DISTVERSION" in
-        xenial|stretch|bionic|buster|focal|bullseye)
+        focal|jammy|buster|bullseye|bookworm)
             cat > /etc/apt/sources.list.d/mysociety-debian.list <<EOF
 deb http://debian.mysociety.org $DISTVERSION main
 EOF
@@ -386,8 +386,6 @@ install_website_packages() {
     EXACT_PACKAGES="$CONF_DIRECTORY/packages.$DISTRIBUTION-$DISTVERSION"
     DIST_PACKAGES="$CONF_DIRECTORY/packages.$DISTRIBUTION"
     FALLBACK_PACKAGES="$CONF_DIRECTORY/packages.generic"
-    PRECISE_PACKAGES="$CONF_DIRECTORY/packages.ubuntu-precise"
-    SQUEEZE_PACKAGES="$CONF_DIRECTORY/packages.debian-squeeze"
     # Allow override by setting PACKAGE_SUFFIX
     if [ -n "$PACKAGE_SUFFIX" ] && [ -e "$CONF_DIRECTORY/packages.$PACKAGE_SUFFIX" ]; then
         PACKAGES_FILE="$CONF_DIRECTORY/packages.$PACKAGE_SUFFIX"
@@ -403,16 +401,6 @@ install_website_packages() {
     elif [ -e "$FALLBACK_PACKAGES" ]
     then
         PACKAGES_FILE="$FALLBACK_PACKAGES"
-    # Otherwise, if this is Ubuntu, and there's a version specifically
-    # for precise, use that:
-    elif [ x"$DISTRIBUTION" = x"ubuntu" ] && [ -e "$PRECISE_PACKAGES" ]
-    then
-        PACKAGES_FILE="$PRECISE_PACKAGES"
-    # Otherwise, if this is Debian, and there's a version specifically
-    # for squeeze, use that:
-    elif [ x"$DISTRIBUTION" = x"debian" ] && [ -e "$SQUEEZE_PACKAGES" ]
-    then
-        PACKAGES_FILE="$SQUEEZE_PACKAGES"
     else
         error_msg "Could not find a packages file to use - please contribute one."
         exit 1

--- a/shlib/installfns
+++ b/shlib/installfns
@@ -136,8 +136,7 @@ update_apt_sources() {
                 : # Do nothing, these should have everything.
                 ;;
             *)
-                error_msg "Unsupported distribution and version combination $DISTRIBUTION $DISTVERSION"
-                exit 1
+                notice_msg "Unsupported distribution and version combination $DISTRIBUTION $DISTVERSION"
                 ;;
         esac
     elif [ x"$DISTRIBUTION" = x"debian" ] ; then
@@ -155,8 +154,7 @@ update_apt_sources() {
                 SECURITY="$DISTVERSION-security"
                 ;;
             *)
-                error_msg "Unsupported distribution and version combination $DISTRIBUTION $DISTVERSION"
-                exit 1
+                notice_msg "Unsupported distribution and version combination $DISTRIBUTION $DISTVERSION"
                 ;;
         esac
         # Install the basic packages we require:
@@ -179,8 +177,7 @@ deb-src http://http.debian.net/debian ${DISTVERSION}-backports main contrib non-
 EOF
         fi
     else
-        error_msg "Unsupported distribution and version combination $DISTRIBUTION $DISTVERSION"
-        exit 1
+        notice_msg "Unsupported distribution and version combination $DISTRIBUTION $DISTVERSION"
     fi
     apt-get -qq update
     echo $DONE_MSG
@@ -202,8 +199,7 @@ EOF
             echo $DONE_MSG
             ;;
         *)
-            error_msg "Unsupported distribution and version combination $DISTRIBUTION $DISTVERSION"
-            exit 1
+            notice_msg "Unsupported distribution and version combination $DISTRIBUTION $DISTVERSION, not adding mySociety repository."
             ;;
     esac
 }

--- a/shlib/installfns
+++ b/shlib/installfns
@@ -337,7 +337,7 @@ install_postgis() {
 make_log_directory() {
     LOG_DIRECTORY="$DIRECTORY/logs"
     mkdir -p "$LOG_DIRECTORY"
-    chown -R "$UNIX_USER"."$UNIX_USER" "$LOG_DIRECTORY"
+    chown -R "$UNIX_USER":"$UNIX_USER" "$LOG_DIRECTORY"
 }
 
 add_website_to_nginx() {


### PR DESCRIPTION
This removes support for Stretch, Xenial and Bionic and adds support for Jammy and Bullseye.

It also updates the format used for APT source definitions to use the newer [deb882](https://manpages.debian.org/unstable/apt/sources.list.5.en.html#DEB822-STYLE_FORMAT) format, used by default in Bookworm and supported on the older systems, and at the same time removes the use of `apt-key` for managing signing keys as this is deprecated.

Fixes #87 
