### PR TITLE
Add default value for APT security repo suite

### DIFF
--- a/bin/install-site.sh
+++ b/bin/install-site.sh
@@ -147,11 +147,9 @@ update_apt_sources() {
                 ;;
             bullseye)
                 BACKPORTS=false
-                SECURITY="$DISTVERSION-security"
                 ;;
             bookworm)
                 BACKPORTS=false
-                SECURITY="$DISTVERSION-security"
                 ;;
             *)
                 notice_msg "Unsupported distribution and version combination $DISTRIBUTION $DISTVERSION"
@@ -170,7 +168,7 @@ Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 # Security Updates:
 Types: deb deb-src
 URIs: http://deb.debian.org/debian-security
-Suites: $SECURITY
+Suites: ${SECURITY:-"$DISTVERSION-security"}
 Components: main contrib non-free
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 

--- a/bin/install-site.sh
+++ b/bin/install-site.sh
@@ -141,14 +141,13 @@ update_apt_sources() {
         esac
     elif [ x"$DISTRIBUTION" = x"debian" ] ; then
         case "$DISTVERSION" in
-            buster)
-                BACKPORTS=false
-                SECURITY="$DISTVERSION/updates"
-                ;;
             bullseye)
                 BACKPORTS=false
                 ;;
             bookworm)
+                BACKPORTS=false
+                ;;
+            trixie)
                 BACKPORTS=false
                 ;;
             *)
@@ -168,7 +167,7 @@ Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 # Security Updates:
 Types: deb deb-src
 URIs: http://deb.debian.org/debian-security
-Suites: ${SECURITY:-"$DISTVERSION-security"}
+Suites: $DISTVERSION-security
 Components: main contrib non-free
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 
@@ -198,7 +197,7 @@ update_mysociety_apt_sources() {
     # We build packages targetted at Debian releases.
     # Try and select the most appropritate ones for Ubuntu.
     case "$DISTVERSION" in
-        focal|jammy|buster|bullseye|bookworm)
+        focal|jammy|bullseye|bookworm|trixie)
             cat > /etc/apt/sources.list.d/mysociety.sources <<EOF
 Types: deb
 URIs: http://debian.mysociety.org

--- a/shlib/installfns
+++ b/shlib/installfns
@@ -147,11 +147,9 @@ update_apt_sources() {
                 ;;
             bullseye)
                 BACKPORTS=false
-                SECURITY="$DISTVERSION-security"
                 ;;
             bookworm)
                 BACKPORTS=false
-                SECURITY="$DISTVERSION-security"
                 ;;
             *)
                 notice_msg "Unsupported distribution and version combination $DISTRIBUTION $DISTVERSION"
@@ -170,7 +168,7 @@ Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 # Security Updates:
 Types: deb deb-src
 URIs: http://deb.debian.org/debian-security
-Suites: $SECURITY
+Suites: ${SECURITY:-"$DISTVERSION-security"}
 Components: main contrib non-free
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 

--- a/shlib/installfns
+++ b/shlib/installfns
@@ -141,14 +141,13 @@ update_apt_sources() {
         esac
     elif [ x"$DISTRIBUTION" = x"debian" ] ; then
         case "$DISTVERSION" in
-            buster)
-                BACKPORTS=false
-                SECURITY="$DISTVERSION/updates"
-                ;;
             bullseye)
                 BACKPORTS=false
                 ;;
             bookworm)
+                BACKPORTS=false
+                ;;
+            trixie)
                 BACKPORTS=false
                 ;;
             *)
@@ -168,7 +167,7 @@ Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 # Security Updates:
 Types: deb deb-src
 URIs: http://deb.debian.org/debian-security
-Suites: ${SECURITY:-"$DISTVERSION-security"}
+Suites: $DISTVERSION-security
 Components: main contrib non-free
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 
@@ -198,7 +197,7 @@ update_mysociety_apt_sources() {
     # We build packages targetted at Debian releases.
     # Try and select the most appropritate ones for Ubuntu.
     case "$DISTVERSION" in
-        focal|jammy|buster|bullseye|bookworm)
+        focal|jammy|bullseye|bookworm|trixie)
             cat > /etc/apt/sources.list.d/mysociety.sources <<EOF
 Types: deb
 URIs: http://debian.mysociety.org


### PR DESCRIPTION
Add fallback default based on distribution version to allow unsupported distributions to install software when explicit security suite config is not available.

Was attempting to install Alaveteli on Trixie but without this change the apt sources are invalid.