### PR TITLE
Add API key header to MapIT request

### DIFF
--- a/phplib/mapit.php
+++ b/phplib/mapit.php
@@ -70,7 +70,11 @@ function mapit_call($url, $params, $opts = array(), $errors = array()) {
         curl_setopt($mapit_ch, CURLOPT_URL, OPTION_MAPIT_URL . $urlp);
         curl_setopt($mapit_ch, CURLOPT_HTTPGET, 1);
         curl_setopt($mapit_ch, CURLOPT_FOLLOWLOCATION, true);
-        curl_setopt($mapit_ch, CURLOPT_HTTPHEADER, array("Pragma: "));
+        $headers = array("Pragma: ");
+        if (defined('OPTION_MAPIT_API_KEY') && OPTION_MAPIT_API_KEY) {
+            $headers[] = 'X-Api-Key: ' . OPTION_MAPIT_API_KEY;
+        }
+        curl_setopt($mapit_ch, CURLOPT_HTTPHEADER, $headers);
     }
 
     if (!($r = curl_exec($mapit_ch))) {


### PR DESCRIPTION
When testing writetothem I eventually run into a mapit API limit and the commonlib doesn't correctly pass on the API key - this does that. 